### PR TITLE
Remove queue from MusicContext provider exports

### DIFF
--- a/client/context/MusicContext.tsx
+++ b/client/context/MusicContext.tsx
@@ -218,7 +218,6 @@ export const MusicProvider: React.FC<MusicProviderProps> = ({ children }) => {
     isShuffle,
     isRepeat,
     likedSongs,
-    queue,
     currentIndex,
     setCurrentSong,
     setIsPlaying,


### PR DESCRIPTION
Remove the `queue` property from the MusicContext provider's exported context values.

This change removes the queue from the list of values being provided by the MusicProvider component in the context export.

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/aa4bb25449864339b2cc55a210059d6e/swoosh-realm)

👀 [Preview Link](https://aa4bb25449864339b2cc55a210059d6e-swoosh-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>aa4bb25449864339b2cc55a210059d6e</projectId>-->
<!--<branchName>swoosh-realm</branchName>-->