### PR TITLE
Implement dark mode with purple/pink theme colors

### DIFF
--- a/client/global.css
+++ b/client/global.css
@@ -124,44 +124,44 @@
     --popover: 0 0% 4%;
     --popover-foreground: 0 0% 100%;
 
-    --primary: 0 100% 50%; /* Red primary (#ff0000) */
+    --primary: 280 100% 70%; /* Bright purple primary */
     --primary-foreground: 0 0% 100%;
 
     --secondary: 0 0% 8%; /* Ultra dark grey secondary (#141414) */
-    --secondary-foreground: 0 0% 95%;
+    --secondary-foreground: 320 30% 85%; /* Light pink text */
 
     --muted: 0 0% 6%; /* Ultra dark muted */
-    --muted-foreground: 0 0% 60%; /* Dimmer grey text */
+    --muted-foreground: 320 25% 75%; /* Pink-tinted grey text */
 
-    --accent: 0 100% 50%; /* Red accent */
+    --accent: 320 100% 75%; /* Bright pink accent */
     --accent-foreground: 0 0% 100%;
 
     --destructive: 0 75% 55%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 0 0% 12%; /* Darker borders */
+    --border: 280 30% 15%; /* Purple-tinted borders */
     --input: 0 0% 3%; /* Ultra dark inputs */
-    --ring: 0 100% 50%;
+    --ring: 280 100% 70%;
     --sidebar-background: 0 0% 2%;
     --sidebar-foreground: 0 0% 100%;
-    --sidebar-primary: 0 100% 50%;
+    --sidebar-primary: 280 100% 70%;
     --sidebar-primary-foreground: 0 0% 100%;
     --sidebar-accent: 0 0% 8%;
-    --sidebar-accent-foreground: 0 0% 95%;
-    --sidebar-border: 0 0% 12%;
-    --sidebar-ring: 0 100% 50%;
+    --sidebar-accent-foreground: 320 30% 85%;
+    --sidebar-border: 280 30% 15%;
+    --sidebar-ring: 280 100% 70%;
 
-    /* Ultra dark theme colors */
-    --purple-primary: 0 100% 50%; /* Red primary */
-    --purple-secondary: 0 0% 65%; /* Light grey secondary */
-    --purple-accent: 0 100% 60%; /* Bright red accent */
-    --purple-glow: 0 100% 70%; /* Red glow */
-    --purple-dark: 0 0% 4%; /* Ultra dark surface (#0a0a0a) */
-    --purple-darker: 0 0% 2%; /* Ultra darker surface (#050505) */
-    --neon-green: 0 100% 50%; /* Red instead of green */
-    --neon-blue: 0 0% 65%; /* Grey instead of blue */
-    --dark-surface: 0 0% 4%; /* Ultra dark surface */
-    --darker-surface: 0 0% 2%; /* Ultra darker surface */
+    /* Purple-pink-white theme colors with black base */
+    --purple-primary: 280 100% 70%; /* Bright purple primary */
+    --purple-secondary: 320 90% 75%; /* Light pink secondary */
+    --purple-accent: 300 100% 80%; /* Bright purple-pink accent */
+    --purple-glow: 290 100% 85%; /* Bright pink-purple glow */
+    --purple-dark: 0 0% 4%; /* Keep black surface (#0a0a0a) */
+    --purple-darker: 0 0% 2%; /* Keep deep black surface (#050505) */
+    --neon-green: 280 100% 70%; /* Purple instead of green */
+    --neon-blue: 320 90% 75%; /* Pink instead of blue */
+    --dark-surface: 0 0% 4%; /* Keep black surface */
+    --darker-surface: 0 0% 2%; /* Keep deep black surface */
   }
 }
 

--- a/client/global.css
+++ b/client/global.css
@@ -115,53 +115,53 @@
   }
 
   .dark {
-    --background: 0 0% 6%; /* YouTube dark background (#0f0f0f) */
+    --background: 0 0% 2%; /* Ultra deep black background (#050505) */
     --foreground: 0 0% 100%; /* Pure white text */
 
-    --card: 0 0% 9%; /* Dark cards (#181818) */
+    --card: 0 0% 4%; /* Very dark cards (#0a0a0a) */
     --card-foreground: 0 0% 100%;
 
-    --popover: 0 0% 9%;
+    --popover: 0 0% 4%;
     --popover-foreground: 0 0% 100%;
 
-    --primary: 0 100% 50%; /* YouTube red primary (#ff0000) */
+    --primary: 0 100% 50%; /* Red primary (#ff0000) */
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 0 0% 15%; /* Dark grey secondary (#272727) */
-    --secondary-foreground: 0 0% 90%;
+    --secondary: 0 0% 8%; /* Ultra dark grey secondary (#141414) */
+    --secondary-foreground: 0 0% 95%;
 
-    --muted: 0 0% 12%; /* Dark grey muted */
-    --muted-foreground: 0 0% 65%; /* Medium grey text */
+    --muted: 0 0% 6%; /* Ultra dark muted */
+    --muted-foreground: 0 0% 60%; /* Dimmer grey text */
 
-    --accent: 0 100% 50%; /* YouTube red accent */
+    --accent: 0 100% 50%; /* Red accent */
     --accent-foreground: 0 0% 100%;
 
     --destructive: 0 75% 55%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 0 0% 20%; /* Dark grey borders */
-    --input: 0 0% 8%; /* Very dark inputs */
+    --border: 0 0% 12%; /* Darker borders */
+    --input: 0 0% 3%; /* Ultra dark inputs */
     --ring: 0 100% 50%;
-    --sidebar-background: 0 0% 6%;
+    --sidebar-background: 0 0% 2%;
     --sidebar-foreground: 0 0% 100%;
     --sidebar-primary: 0 100% 50%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 0 0% 15%;
-    --sidebar-accent-foreground: 0 0% 90%;
-    --sidebar-border: 0 0% 20%;
+    --sidebar-accent: 0 0% 8%;
+    --sidebar-accent-foreground: 0 0% 95%;
+    --sidebar-border: 0 0% 12%;
     --sidebar-ring: 0 100% 50%;
 
-    /* YouTube-style theme colors for dark mode */
-    --purple-primary: 0 100% 50%; /* YouTube red primary */
-    --purple-secondary: 0 0% 70%; /* Light grey secondary */
+    /* Ultra dark theme colors */
+    --purple-primary: 0 100% 50%; /* Red primary */
+    --purple-secondary: 0 0% 65%; /* Light grey secondary */
     --purple-accent: 0 100% 60%; /* Bright red accent */
     --purple-glow: 0 100% 70%; /* Red glow */
-    --purple-dark: 0 0% 9%; /* Dark surface (#181818) */
-    --purple-darker: 0 0% 6%; /* Darker surface (#0f0f0f) */
+    --purple-dark: 0 0% 4%; /* Ultra dark surface (#0a0a0a) */
+    --purple-darker: 0 0% 2%; /* Ultra darker surface (#050505) */
     --neon-green: 0 100% 50%; /* Red instead of green */
-    --neon-blue: 0 0% 70%; /* Grey instead of blue */
-    --dark-surface: 0 0% 9%; /* Dark surface */
-    --darker-surface: 0 0% 6%; /* Darker surface */
+    --neon-blue: 0 0% 65%; /* Grey instead of blue */
+    --dark-surface: 0 0% 4%; /* Ultra dark surface */
+    --darker-surface: 0 0% 2%; /* Ultra darker surface */
   }
 }
 

--- a/client/global.css
+++ b/client/global.css
@@ -9,57 +9,57 @@
    * A different format will require also updating the theme in tailwind.config.ts.
   */
   :root {
-    /* Purple Dark Mode */
-    --background: 0 0% 7%; /* Dark background */
-    --foreground: 0 0% 95%; /* Light text */
+    /* Default Dark Mode - Based on palette */
+    --background: 0 0% 4%; /* #0A0A0A - Very dark background */
+    --foreground: 0 0% 98%; /* #FAFAFA - Light text */
 
-    --card: 0 0% 10%; /* Dark cards */
-    --card-foreground: 0 0% 95%;
+    --card: 0 0% 9%; /* #171717 - Dark cards */
+    --card-foreground: 0 0% 98%;
 
-    --popover: 0 0% 10%;
-    --popover-foreground: 0 0% 95%;
+    --popover: 0 0% 9%;
+    --popover-foreground: 0 0% 98%;
 
-    --primary: 270 95% 60%; /* Purple primary for buttons */
+    --primary: 280 100% 70%; /* Bright purple primary */
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 0 0% 15%; /* Dark secondary */
-    --secondary-foreground: 0 0% 95%;
+    --secondary: 0 0% 15%; /* #262626 - Dark secondary */
+    --secondary-foreground: 0 0% 90%;
 
-    --muted: 0 0% 12%; /* Dark muted */
-    --muted-foreground: 0 0% 70%; /* Gray text */
+    --muted: 0 0% 22%; /* #373737 - Dark muted */
+    --muted-foreground: 0 0% 64%; /* #A3A3A3 - Medium gray text */
 
-    --accent: 270 95% 60%; /* Purple accent */
+    --accent: 320 100% 75%; /* Bright pink accent */
     --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 0 0% 20%; /* Gray borders */
-    --input: 0 0% 12%; /* Dark inputs */
-    --ring: 270 95% 60%;
+    --border: 0 0% 32%; /* #525252 - Gray borders */
+    --input: 0 0% 9%; /* #171717 - Dark inputs */
+    --ring: 280 100% 70%;
 
     --radius: 0.75rem;
 
-    --sidebar-background: 0 0% 7%;
-    --sidebar-foreground: 0 0% 95%;
-    --sidebar-primary: 270 95% 60%;
+    --sidebar-background: 0 0% 4%;
+    --sidebar-foreground: 0 0% 98%;
+    --sidebar-primary: 280 100% 70%;
     --sidebar-primary-foreground: 0 0% 100%;
     --sidebar-accent: 0 0% 15%;
-    --sidebar-accent-foreground: 0 0% 95%;
-    --sidebar-border: 0 0% 20%;
-    --sidebar-ring: 270 95% 60%;
+    --sidebar-accent-foreground: 0 0% 90%;
+    --sidebar-border: 0 0% 32%;
+    --sidebar-ring: 280 100% 70%;
 
     /* Purple theme colors */
-    --purple-primary: 270 95% 60%; /* Bright purple */
-    --purple-secondary: 285 85% 65%; /* Light purple */
-    --purple-accent: 255 90% 70%; /* Purple-pink */
-    --purple-glow: 270 95% 80%; /* Light purple glow */
-    --purple-dark: 0 0% 10%; /* Dark surface */
-    --purple-darker: 0 0% 7%; /* Darker surface */
-    --neon-green: 270 95% 60%; /* Purple instead of green */
-    --neon-blue: 285 85% 65%; /* Light purple instead of blue */
-    --dark-surface: 0 0% 10%;
-    --darker-surface: 0 0% 7%;
+    --purple-primary: 280 100% 70%; /* Bright purple */
+    --purple-secondary: 320 90% 75%; /* Light pink-purple */
+    --purple-accent: 300 100% 80%; /* Bright purple-pink */
+    --purple-glow: 290 100% 85%; /* Light purple glow */
+    --purple-dark: 0 0% 9%; /* #171717 - Dark surface */
+    --purple-darker: 0 0% 4%; /* #0A0A0A - Darker surface */
+    --neon-green: 280 100% 70%; /* Purple primary */
+    --neon-blue: 320 90% 75%; /* Pink-purple */
+    --dark-surface: 0 0% 9%;
+    --darker-surface: 0 0% 4%;
   }
 
   .light {

--- a/client/global.css
+++ b/client/global.css
@@ -115,23 +115,23 @@
   }
 
   .dark {
-    --background: 0 0% 2%; /* Ultra deep black background (#050505) */
-    --foreground: 0 0% 100%; /* Pure white text */
+    --background: 0 0% 0%; /* #000000 - Pure black background */
+    --foreground: 0 0% 98%; /* #FAFAFA - Light text */
 
-    --card: 0 0% 4%; /* Very dark cards (#0a0a0a) */
-    --card-foreground: 0 0% 100%;
+    --card: 0 0% 4%; /* #0A0A0A - Very dark cards */
+    --card-foreground: 0 0% 98%;
 
     --popover: 0 0% 4%;
-    --popover-foreground: 0 0% 100%;
+    --popover-foreground: 0 0% 98%;
 
     --primary: 280 100% 70%; /* Bright purple primary */
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 0 0% 8%; /* Ultra dark grey secondary (#141414) */
+    --secondary: 0 0% 9%; /* #171717 - Dark secondary */
     --secondary-foreground: 320 30% 85%; /* Light pink text */
 
-    --muted: 0 0% 6%; /* Ultra dark muted */
-    --muted-foreground: 320 25% 75%; /* Pink-tinted grey text */
+    --muted: 0 0% 15%; /* #262626 - Dark muted */
+    --muted-foreground: 320 25% 75%; /* Pink-tinted gray text */
 
     --accent: 320 100% 75%; /* Bright pink accent */
     --accent-foreground: 0 0% 100%;
@@ -139,29 +139,29 @@
     --destructive: 0 75% 55%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 280 30% 15%; /* Purple-tinted borders */
-    --input: 0 0% 3%; /* Ultra dark inputs */
+    --border: 0 0% 22%; /* #373737 - Dark borders */
+    --input: 0 0% 4%; /* #0A0A0A - Very dark inputs */
     --ring: 280 100% 70%;
-    --sidebar-background: 0 0% 2%;
-    --sidebar-foreground: 0 0% 100%;
+    --sidebar-background: 0 0% 0%;
+    --sidebar-foreground: 0 0% 98%;
     --sidebar-primary: 280 100% 70%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 0 0% 8%;
+    --sidebar-accent: 0 0% 9%;
     --sidebar-accent-foreground: 320 30% 85%;
-    --sidebar-border: 280 30% 15%;
+    --sidebar-border: 0 0% 22%;
     --sidebar-ring: 280 100% 70%;
 
-    /* Purple-pink-white theme colors with black base */
+    /* Purple-pink theme colors with pure black base */
     --purple-primary: 280 100% 70%; /* Bright purple primary */
     --purple-secondary: 320 90% 75%; /* Light pink secondary */
     --purple-accent: 300 100% 80%; /* Bright purple-pink accent */
     --purple-glow: 290 100% 85%; /* Bright pink-purple glow */
-    --purple-dark: 0 0% 4%; /* Keep black surface (#0a0a0a) */
-    --purple-darker: 0 0% 2%; /* Keep deep black surface (#050505) */
+    --purple-dark: 0 0% 4%; /* #0A0A0A - Very dark surface */
+    --purple-darker: 0 0% 0%; /* #000000 - Pure black surface */
     --neon-green: 280 100% 70%; /* Purple instead of green */
     --neon-blue: 320 90% 75%; /* Pink instead of blue */
-    --dark-surface: 0 0% 4%; /* Keep black surface */
-    --darker-surface: 0 0% 2%; /* Keep deep black surface */
+    --dark-surface: 0 0% 4%; /* Very dark surface */
+    --darker-surface: 0 0% 0%; /* Pure black surface */
   }
 }
 

--- a/client/global.css
+++ b/client/global.css
@@ -115,53 +115,53 @@
   }
 
   .dark {
-    --background: 0 0% 3%; /* Pure deep black background */
-    --foreground: 0 0% 95%; /* Light text */
+    --background: 310 40% 8%; /* Deep purple-black background */
+    --foreground: 0 0% 98%; /* Pure white text */
 
-    --card: 0 0% 5%; /* Very dark cards */
-    --card-foreground: 0 0% 95%;
+    --card: 320 30% 12%; /* Dark purple cards */
+    --card-foreground: 0 0% 98%;
 
-    --popover: 0 0% 5%;
-    --popover-foreground: 0 0% 95%;
+    --popover: 320 30% 12%;
+    --popover-foreground: 0 0% 98%;
 
-    --primary: 270 95% 60%; /* Purple primary for buttons */
+    --primary: 300 100% 70%; /* Bright purple-pink primary */
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 0 0% 7%; /* Very dark secondary */
-    --secondary-foreground: 0 0% 85%;
+    --secondary: 315 25% 15%; /* Dark purple secondary */
+    --secondary-foreground: 0 0% 95%;
 
-    --muted: 0 0% 6%; /* Very dark muted */
-    --muted-foreground: 0 0% 65%; /* Medium gray text */
+    --muted: 310 35% 10%; /* Deep purple muted */
+    --muted-foreground: 320 20% 80%; /* Light purple-gray text */
 
-    --accent: 270 95% 60%; /* Purple accent */
+    --accent: 290 100% 75%; /* Bright pink-purple accent */
     --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 75% 55%;
+    --destructive: 350 75% 65%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 0 0% 10%; /* Dark borders */
-    --input: 0 0% 4%; /* Very dark inputs */
-    --ring: 270 95% 60%;
-    --sidebar-background: 0 0% 3%;
-    --sidebar-foreground: 0 0% 95%;
-    --sidebar-primary: 270 95% 60%;
+    --border: 320 25% 20%; /* Purple borders */
+    --input: 315 30% 8%; /* Dark purple inputs */
+    --ring: 300 100% 70%;
+    --sidebar-background: 310 40% 8%;
+    --sidebar-foreground: 0 0% 98%;
+    --sidebar-primary: 300 100% 70%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 0 0% 7%;
-    --sidebar-accent-foreground: 0 0% 85%;
-    --sidebar-border: 0 0% 10%;
-    --sidebar-ring: 270 95% 60%;
+    --sidebar-accent: 315 25% 15%;
+    --sidebar-accent-foreground: 0 0% 95%;
+    --sidebar-border: 320 25% 20%;
+    --sidebar-ring: 300 100% 70%;
 
-    /* Purple theme colors for deep dark mode */
-    --purple-primary: 270 95% 60%; /* Bright purple primary */
-    --purple-secondary: 285 85% 65%; /* Light purple secondary */
-    --purple-accent: 255 90% 70%; /* Purple-pink accent */
-    --purple-glow: 270 95% 80%; /* Light purple glow */
-    --purple-dark: 0 0% 5%; /* Very dark surface */
-    --purple-darker: 0 0% 3%; /* Deepest dark surface */
-    --neon-green: 270 95% 60%; /* Purple instead of green */
-    --neon-blue: 285 85% 65%; /* Light purple instead of blue */
-    --dark-surface: 0 0% 5%; /* Very dark surface */
-    --darker-surface: 0 0% 3%; /* Deepest dark surface */
+    /* Purple-pink-white theme colors for dark mode */
+    --purple-primary: 300 100% 70%; /* Bright purple-pink primary */
+    --purple-secondary: 320 90% 75%; /* Light pink-purple secondary */
+    --purple-accent: 290 100% 80%; /* Bright pink accent */
+    --purple-glow: 300 100% 85%; /* Light purple-pink glow */
+    --purple-dark: 320 30% 12%; /* Dark purple surface */
+    --purple-darker: 310 40% 8%; /* Deeper purple surface */
+    --neon-green: 300 100% 70%; /* Purple-pink instead of green */
+    --neon-blue: 320 90% 75%; /* Light pink-purple instead of blue */
+    --dark-surface: 320 30% 12%; /* Dark purple surface */
+    --darker-surface: 310 40% 8%; /* Deeper purple surface */
   }
 }
 

--- a/client/global.css
+++ b/client/global.css
@@ -63,55 +63,55 @@
   }
 
   .light {
-    /* Light Purple with White Text Mode */
-    --background: 295 70% 97%; /* Very light purple background (#F5EBFA) */
-    --foreground: 0 0% 100%; /* Pure white text */
+    /* Clean Light Mode - Based on palette */
+    --background: 0 0% 100%; /* #FFFFFF - Pure white background */
+    --foreground: 0 0% 4%; /* #0A0A0A - Dark text */
 
-    --card: 295 40% 94%; /* Light purple cards (#E7DBEF) */
-    --card-foreground: 0 0% 100%; /* White text on cards */
+    --card: 0 0% 98%; /* #FAFAFA - Light cards */
+    --card-foreground: 0 0% 4%; /* Dark text on cards */
 
-    --popover: 295 40% 94%;
-    --popover-foreground: 0 0% 100%;
+    --popover: 0 0% 98%;
+    --popover-foreground: 0 0% 4%;
 
-    --primary: 0 0% 0%; /* Black primary buttons */
-    --primary-foreground: 0 0% 100%; /* White text on black buttons */
+    --primary: 0 0% 4%; /* #0A0A0A - Dark primary buttons */
+    --primary-foreground: 0 0% 100%; /* White text on dark buttons */
 
-    --secondary: 295 40% 94%; /* Light purple secondary (#E7DBEF) */
-    --secondary-foreground: 0 0% 100%; /* White text */
+    --secondary: 0 0% 96%; /* #F5F5F5 - Light secondary */
+    --secondary-foreground: 0 0% 4%; /* Dark text */
 
-    --muted: 295 50% 91%; /* Medium light purple background */
-    --muted-foreground: 0 0% 80%; /* Light gray for subtle text */
+    --muted: 0 0% 90%; /* #E5E5E5 - Light muted */
+    --muted-foreground: 0 0% 45%; /* #737373 - Medium gray text */
 
-    --accent: 283 35% 60%; /* Light purple accent (#A56ABD) */
+    --accent: 280 100% 70%; /* Purple accent */
     --accent-foreground: 0 0% 100%; /* White text on accent */
 
-    --destructive: 0 100% 40%; /* Red for errors */
+    --destructive: 0 84% 60%; /* Red for errors */
     --destructive-foreground: 0 0% 100%;
 
-    --border: 295 30% 85%; /* Light purple borders */
-    --input: 295 50% 96%; /* Very light purple inputs */
-    --ring: 0 0% 100%; /* White focus ring */
+    --border: 0 0% 83%; /* #D4D4D4 - Light borders */
+    --input: 0 0% 98%; /* #FAFAFA - Light inputs */
+    --ring: 280 100% 70%; /* Purple focus ring */
 
-    --sidebar-background: 295 70% 97%;
-    --sidebar-foreground: 0 0% 100%;
-    --sidebar-primary: 0 0% 0%;
+    --sidebar-background: 0 0% 100%;
+    --sidebar-foreground: 0 0% 4%;
+    --sidebar-primary: 0 0% 4%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 295 40% 94%;
-    --sidebar-accent-foreground: 0 0% 100%;
-    --sidebar-border: 295 30% 85%;
-    --sidebar-ring: 0 0% 100%;
+    --sidebar-accent: 0 0% 96%;
+    --sidebar-accent-foreground: 0 0% 4%;
+    --sidebar-border: 0 0% 83%;
+    --sidebar-ring: 280 100% 70%;
 
-    /* Light purple theme colors with white text */
-    --purple-primary: 0 0% 100%; /* White instead of black */
-    --purple-secondary: 283 35% 60%; /* Light purple (#A56ABD) */
-    --purple-accent: 283 35% 70%; /* Lighter purple */
-    --purple-glow: 283 35% 60%; /* Light purple glow */
-    --purple-dark: 295 40% 94%; /* Light purple background (#E7DBEF) */
-    --purple-darker: 295 70% 97%; /* Very light purple (#F5EBFA) */
-    --neon-green: 0 0% 100%; /* White instead of black */
-    --neon-blue: 283 35% 60%; /* Light purple instead of blue */
-    --dark-surface: 295 40% 94%; /* Light purple surface */
-    --darker-surface: 295 70% 97%; /* Very light purple surface */
+    /* Light theme colors */
+    --purple-primary: 280 100% 70%; /* Purple primary */
+    --purple-secondary: 320 90% 75%; /* Light pink-purple */
+    --purple-accent: 300 100% 80%; /* Bright purple-pink */
+    --purple-glow: 290 100% 85%; /* Light purple glow */
+    --purple-dark: 0 0% 98%; /* #FAFAFA - Light surface */
+    --purple-darker: 0 0% 100%; /* #FFFFFF - White surface */
+    --neon-green: 280 100% 70%; /* Purple primary */
+    --neon-blue: 320 90% 75%; /* Pink-purple */
+    --dark-surface: 0 0% 98%; /* Light surface */
+    --darker-surface: 0 0% 100%; /* White surface */
   }
 
   .dark {

--- a/client/global.css
+++ b/client/global.css
@@ -115,53 +115,53 @@
   }
 
   .dark {
-    --background: 310 40% 8%; /* Deep purple-black background */
-    --foreground: 0 0% 98%; /* Pure white text */
+    --background: 0 0% 6%; /* YouTube dark background (#0f0f0f) */
+    --foreground: 0 0% 100%; /* Pure white text */
 
-    --card: 320 30% 12%; /* Dark purple cards */
-    --card-foreground: 0 0% 98%;
+    --card: 0 0% 9%; /* Dark cards (#181818) */
+    --card-foreground: 0 0% 100%;
 
-    --popover: 320 30% 12%;
-    --popover-foreground: 0 0% 98%;
+    --popover: 0 0% 9%;
+    --popover-foreground: 0 0% 100%;
 
-    --primary: 300 100% 70%; /* Bright purple-pink primary */
+    --primary: 0 100% 50%; /* YouTube red primary (#ff0000) */
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 315 25% 15%; /* Dark purple secondary */
-    --secondary-foreground: 0 0% 95%;
+    --secondary: 0 0% 15%; /* Dark grey secondary (#272727) */
+    --secondary-foreground: 0 0% 90%;
 
-    --muted: 310 35% 10%; /* Deep purple muted */
-    --muted-foreground: 320 20% 80%; /* Light purple-gray text */
+    --muted: 0 0% 12%; /* Dark grey muted */
+    --muted-foreground: 0 0% 65%; /* Medium grey text */
 
-    --accent: 290 100% 75%; /* Bright pink-purple accent */
+    --accent: 0 100% 50%; /* YouTube red accent */
     --accent-foreground: 0 0% 100%;
 
-    --destructive: 350 75% 65%;
+    --destructive: 0 75% 55%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 320 25% 20%; /* Purple borders */
-    --input: 315 30% 8%; /* Dark purple inputs */
-    --ring: 300 100% 70%;
-    --sidebar-background: 310 40% 8%;
-    --sidebar-foreground: 0 0% 98%;
-    --sidebar-primary: 300 100% 70%;
+    --border: 0 0% 20%; /* Dark grey borders */
+    --input: 0 0% 8%; /* Very dark inputs */
+    --ring: 0 100% 50%;
+    --sidebar-background: 0 0% 6%;
+    --sidebar-foreground: 0 0% 100%;
+    --sidebar-primary: 0 100% 50%;
     --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 315 25% 15%;
-    --sidebar-accent-foreground: 0 0% 95%;
-    --sidebar-border: 320 25% 20%;
-    --sidebar-ring: 300 100% 70%;
+    --sidebar-accent: 0 0% 15%;
+    --sidebar-accent-foreground: 0 0% 90%;
+    --sidebar-border: 0 0% 20%;
+    --sidebar-ring: 0 100% 50%;
 
-    /* Purple-pink-white theme colors for dark mode */
-    --purple-primary: 300 100% 70%; /* Bright purple-pink primary */
-    --purple-secondary: 320 90% 75%; /* Light pink-purple secondary */
-    --purple-accent: 290 100% 80%; /* Bright pink accent */
-    --purple-glow: 300 100% 85%; /* Light purple-pink glow */
-    --purple-dark: 320 30% 12%; /* Dark purple surface */
-    --purple-darker: 310 40% 8%; /* Deeper purple surface */
-    --neon-green: 300 100% 70%; /* Purple-pink instead of green */
-    --neon-blue: 320 90% 75%; /* Light pink-purple instead of blue */
-    --dark-surface: 320 30% 12%; /* Dark purple surface */
-    --darker-surface: 310 40% 8%; /* Deeper purple surface */
+    /* YouTube-style theme colors for dark mode */
+    --purple-primary: 0 100% 50%; /* YouTube red primary */
+    --purple-secondary: 0 0% 70%; /* Light grey secondary */
+    --purple-accent: 0 100% 60%; /* Bright red accent */
+    --purple-glow: 0 100% 70%; /* Red glow */
+    --purple-dark: 0 0% 9%; /* Dark surface (#181818) */
+    --purple-darker: 0 0% 6%; /* Darker surface (#0f0f0f) */
+    --neon-green: 0 100% 50%; /* Red instead of green */
+    --neon-blue: 0 0% 70%; /* Grey instead of blue */
+    --dark-surface: 0 0% 9%; /* Dark surface */
+    --darker-surface: 0 0% 6%; /* Darker surface */
   }
 }
 

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -362,16 +362,16 @@ export default function Profile() {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground relative overflow-hidden theme-transition">
-      {/* Clean YouTube/Google style background */}
+    <div className="h-screen bg-background text-foreground relative overflow-hidden theme-transition max-w-sm mx-auto">
+      {/* App background */}
       <div className="fixed inset-0 bg-gradient-to-b from-background to-secondary/30 theme-transition"></div>
 
       <div className="relative z-10 flex flex-col h-screen">
-        {/* Header - Claude/AI Style */}
+        {/* Compact App Header */}
         <motion.header
           initial={{ y: -50, opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          className="flex items-center justify-between p-4 bg-background/95 backdrop-blur-sm border-b border-border claude-shadow dark:claude-dark-shadow theme-transition"
+          className="flex items-center justify-between px-3 py-2 bg-background/95 backdrop-blur-sm border-b border-border theme-transition"
         >
           <motion.button
             whileHover={{ scale: 1.05 }}

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -725,7 +725,7 @@ export default function Profile() {
 
             {/* Stats */}
             {!isEditing && (
-              <div className="grid grid-cols-3 gap-4 mb-6">
+              <div className="grid grid-cols-3 gap-2 mb-4">
                 <motion.button
                   whileHover={{ scale: 1.01 }}
                   whileTap={{ scale: 0.99 }}

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -377,14 +377,14 @@ export default function Profile() {
             whileHover={{ scale: 1.05 }}
             whileTap={{ scale: 0.95 }}
             onClick={() => navigate("/home")}
-            className="w-10 h-10 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors"
+            className="w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors"
           >
-            <ArrowLeft className="w-5 h-5 text-foreground" />
+            <ArrowLeft className="w-4 h-4 text-foreground" />
           </motion.button>
 
-          <h1 className="text-lg font-bold text-foreground">Profile</h1>
+          <h1 className="text-base font-bold text-foreground">Profile</h1>
 
-          <div className="flex items-center space-x-2">
+          <div className="flex items-center space-x-1">
             {!isEditing ? (
               <motion.button
                 whileHover={{ scale: 1.05 }}

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -633,16 +633,16 @@ export default function Profile() {
                 </div>
               ) : (
                 <>
-                  <div className="flex items-center space-x-2 mb-2">
-                    <h1 className="text-2xl font-bold text-foreground">{profile.displayName}</h1>
+                  <div className="flex items-center space-x-2 mb-1.5">
+                    <h1 className="text-xl font-bold text-foreground">{profile.displayName}</h1>
                     {profile.isArtist && (
-                      <div className="px-2 py-1 bg-primary/10 rounded-full">
+                      <div className="px-1.5 py-0.5 bg-primary/10 rounded-full">
                         <span className="text-xs text-primary font-medium">Artist</span>
                       </div>
                     )}
                   </div>
-                  <p className="text-muted-foreground mb-1">@{profile.username}</p>
-                  <p className="text-foreground leading-relaxed mb-3">{profile.bio}</p>
+                  <p className="text-sm text-muted-foreground mb-1">@{profile.username}</p>
+                  <p className="text-sm text-foreground leading-relaxed mb-2">{profile.bio}</p>
                   
                   {/* Location and Website */}
                   <div className="flex items-center space-x-4 text-sm text-muted-foreground mb-3">

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -519,7 +519,7 @@ export default function Profile() {
             </div>
 
             {/* Name and Bio */}
-            <div className="mb-4">
+            <div className="mb-3">
               {isEditing ? (
                 <div className="space-y-4">
                   {/* Display Name */}

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -730,10 +730,10 @@ export default function Profile() {
                   whileHover={{ scale: 1.01 }}
                   whileTap={{ scale: 0.99 }}
                   onClick={() => setShowStats(true)}
-                  className="text-center p-3 bg-card rounded-lg border border-border hover:bg-muted/50 transition-colors claude-shadow hover:claude-shadow-hover dark:claude-dark-shadow dark:hover:claude-dark-shadow-hover"
+                  className="text-center p-2.5 bg-card rounded-lg border border-border hover:bg-muted/50 transition-colors"
                 >
-                  <p className="text-xl font-bold text-foreground">{formatNumber(profile.stats.followers)}</p>
-                  <p className="text-sm text-muted-foreground">Followers</p>
+                  <p className="text-lg font-bold text-foreground">{formatNumber(profile.stats.followers)}</p>
+                  <p className="text-xs text-muted-foreground">Followers</p>
                 </motion.button>
 
                 <motion.button

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -457,14 +457,14 @@ export default function Profile() {
           </div>
 
           {/* Profile Info */}
-          <div className="px-4 -mt-16 relative z-10">
+          <div className="px-3 -mt-12 relative z-10">
             {/* Avatar */}
-            <div className="flex items-end justify-between mb-4">
+            <div className="flex items-end justify-between mb-3">
               <div className="relative">
                 <img
                   src={profile.avatar}
                   alt={profile.displayName}
-                  className="w-24 h-24 rounded-full object-cover border-4 border-background shadow-xl"
+                  className="w-20 h-20 rounded-full object-cover border-3 border-background shadow-lg"
                 />
                 {profile.isVerified && (
                   <div className="absolute -bottom-1 -right-1 w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center border-2 border-background">

--- a/client/pages/Profile.tsx
+++ b/client/pages/Profile.tsx
@@ -436,9 +436,9 @@ export default function Profile() {
         </motion.header>
 
         {/* Main Content */}
-        <div className="flex-1 overflow-y-auto pb-24">
-          {/* Cover Image */}
-          <div className="relative h-48 sm:h-64">
+        <div className="flex-1 overflow-y-auto pb-20">
+          {/* Compact Cover Image */}
+          <div className="relative h-32">
             <img
               src={profile.coverImage}
               alt="Cover"


### PR DESCRIPTION
## Purpose
Based on user feedback, this PR implements a comprehensive dark mode with purple, pink, and white color scheme while maintaining both light and dark mode options. Users specifically requested YouTube-style dark mode with purple/pink accent colors instead of removing the existing black color scheme entirely.

## Code changes
- **CSS Color Variables**: Updated all CSS custom properties in `global.css` to support three distinct themes:
  - Default dark mode with purple (#280 100% 70%) and pink (#320 100% 75%) accents
  - Clean light mode with white background and dark text
  - Pure black dark mode with enhanced purple-pink color palette
- **Profile Component**: Converted profile page to mobile app layout with:
  - Compact header design (reduced padding and sizing)
  - Smaller cover image height (48px → 32px)
  - Condensed avatar and stats sections
  - Mobile-first responsive design with max-width container
- **Theme Integration**: All color variables now properly support the purple/pink theme across light and dark modes while preserving the black color foundation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 28`

🔗 [Edit in Builder.io](https://builder.io/app/projects/b499d7cb6e0b44ceb72c6a02f142a068/neon-field)

👀 [Preview Link](https://b499d7cb6e0b44ceb72c6a02f142a068-neon-field.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>b499d7cb6e0b44ceb72c6a02f142a068</projectId>-->
<!--<branchName>neon-field</branchName>-->